### PR TITLE
Add 'requirements.txt'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+daemonize


### PR DESCRIPTION
Hey @arturmeski!

Thanks for building this awesome tool 😃 

I noticed that your repo doesn't come with a `requirements.txt` file to help people quickly run Postfix Monitor (and Defender) so I thought it might be handy to add one.

Please let me know if there is a code of conduct/license agreement/developer statement I need to make to contribute to your repo.

Thanks again for your hard work! 

> Signed-off-by: Andrew V. Teylu <andrew@tey.lu>